### PR TITLE
Add Channel Permissions

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -23,7 +23,9 @@ export default interface Command {
   run(interaction: CommandInteraction): Promise<void> | void;
 
   /**
-   * The channel ID's that this command is allowed in.
+   * The channel IDs that this command is allowed in.
+   * If a value is not provided this command is allowed to be
+   * used in any channel.
    */
   allowedChannels?: Snowflake[];
 }

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -28,7 +28,6 @@ export default interface Command {
   allowedChannels?: Snowflake[];
 }
 
-
 /**
  * Returns whether an object of unknown type is a Command.
  * @param maybeCommand The denormalized command type to check.

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionData, CommandInteraction } from 'discord.js';
+import { ApplicationCommandOptionData, CommandInteraction, Snowflake } from 'discord.js';
 
 export default interface Command {
   /**
@@ -21,7 +21,13 @@ export default interface Command {
    * is invoked.
    */
   run(interaction: CommandInteraction): Promise<void> | void;
+
+  /**
+   * The channel ID's that this command is allowed in.
+   */
+  allowedChannels?: Snowflake[];
 }
+
 
 /**
  * Returns whether an object of unknown type is a Command.

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -1,4 +1,8 @@
-import { ApplicationCommandOptionData, CommandInteraction, Snowflake } from 'discord.js';
+import {
+  ApplicationCommandOptionData,
+  CommandInteraction,
+  Snowflake,
+} from 'discord.js';
 
 export default interface Command {
   /**
@@ -24,7 +28,7 @@ export default interface Command {
 
   /**
    * The channel IDs that this command is allowed in.
-   * If a value is not provided this command is allowed to be
+   * If a value is not provided, this command is allowed to be
    * used in any channel.
    */
   allowedChannels?: Snowflake[];

--- a/src/MessageDispatcher.ts
+++ b/src/MessageDispatcher.ts
@@ -7,6 +7,25 @@ export default class MessageDispatcher implements Dispatchable {
 
   public async dispatch(interaction: CommandInteraction): Promise<void> {
     const command = this.manager.lookup(interaction.commandName);
-    await command?.run(interaction);
+
+    // This should ideally never happen.
+    if (!command) {
+      interaction.reply('Error finding that command');
+      return;
+    }
+
+    // Check channel permissions
+    if (command.allowedChannels) {
+      if (!command.allowedChannels.includes(interaction.channelId)) {
+        const errMsg = 'Please use this command in an allowed channel:\n'
+          .concat(...command.allowedChannels.map(channel => `- <#${channel}>\n`));
+
+        // Send error message.
+        interaction.reply({ content: errMsg, ephemeral: true });
+        return;
+      }
+    }
+
+    await command.run(interaction);
   }
 }


### PR DESCRIPTION
Adds an optional `allowedChannels` field to `Command`. This enforces that the command can only be run in certain channels. On the client side it presents an ephemeral message showing the error:

<img width="438" alt="Screen Shot 2021-07-12 at 1 53 43 PM" src="https://user-images.githubusercontent.com/77477100/125334505-73b71d00-e319-11eb-8d86-6a89355ac189.png">
 