### PR TITLE
Add API Permission checking

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -106,7 +106,7 @@ export default class Client extends discord.Client {
  */
 function toAppCommand(command: Command): ApplicationCommandData {
 
-  const defaultPermission: boolean = (command.guildRoles ?? command.guildUsers) === undefined;
+  const defaultPermission: boolean = (command.allowedRoles ?? command.allowedUsers) === undefined;
 
   return {
     name: command.name,
@@ -121,8 +121,8 @@ function applyPermissions(commands: Command[], command: ApplicationCommand): Gui
 
   const permissions: ApplicationCommandPermissionData[] = [];
 
-  if (fetchedCommand?.guildRoles) {
-    permissions.push(...fetchedCommand.guildRoles.map((role): ApplicationCommandPermissionData => (
+  if (fetchedCommand?.allowedRoles) {
+    permissions.push(...fetchedCommand.allowedRoles.map((role): ApplicationCommandPermissionData => (
       {
         type: 'ROLE',
         id: role,
@@ -131,8 +131,8 @@ function applyPermissions(commands: Command[], command: ApplicationCommand): Gui
     )));
   }
 
-  if (fetchedCommand?.guildUsers) {
-    permissions.push(...fetchedCommand.guildUsers.map((user): ApplicationCommandPermissionData => (
+  if (fetchedCommand?.allowedUsers) {
+    permissions.push(...fetchedCommand.allowedUsers.map((user): ApplicationCommandPermissionData => (
       {
         type: 'USER',
         id: user,

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -34,12 +34,12 @@ export interface Command {
   /**
    * The static role permissions for this command.
    */
-  guildRoles?: Snowflake[];
+  allowedRoles?: Snowflake[];
 
   /**
    * The static user permissions for this commands
    */
-  guildUsers?: Snowflake[];
+  allowedUsers?: Snowflake[];
 
   /**
    * The {@link PermissionHandler} that handles the permissions for this command.

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -44,7 +44,7 @@ export interface Command {
   /**
    * The {@link PermissionHandler} that handles the permissions for this command.
    */
-  readonly permissions?: PermissionHandler;
+  readonly permissionsHandler?: PermissionHandler;
 }
 
 /**

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -44,7 +44,7 @@ export interface Command {
   /**
    * The {@link PermissionHandler} that handles the permissions for this command.
    */
-  readonly permissionsHandler?: PermissionHandler;
+  readonly permissionHandler?: PermissionHandler;
 }
 
 /**

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -1,6 +1,7 @@
 import {
   ApplicationCommandOptionData,
   CommandInteraction,
+  Snowflake,
 } from 'discord.js';
 
 export type PermissionHandler = (interaction: CommandInteraction) => boolean | Promise<boolean>;
@@ -29,6 +30,16 @@ export interface Command {
    * is invoked.
    */
   run(interaction: CommandInteraction): Promise<void> | void;
+
+  /**
+   * The static role permissions for this command.
+   */
+  guildRoles?: Snowflake[];
+
+  /**
+   * The static user permissions for this commands
+   */
+  guildUsers?: Snowflake[];
 
   /**
    * The {@link PermissionHandler} that handles the permissions for this command.

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -14,8 +14,8 @@ export async function dispatch(
     return;
   }
 
-  if (command.permissions) {
-    const check = await command.permissions(interaction);
+  if (command.permissionsHandler) {
+    const check = await command.permissionsHandler(interaction);
     if (!check) {
       /*
        * It's not guaranteed that an interaction will be responded to

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -14,8 +14,8 @@ export async function dispatch(
     return;
   }
 
-  if (command.permissionsHandler) {
-    const check = await command.permissionsHandler(interaction);
+  if (command.permissionHandler) {
+    const check = await command.permissionHandler(interaction);
     if (!check) {
       /*
        * It's not guaranteed that an interaction will be responded to


### PR DESCRIPTION
This adds an `guildRoles` and `guildUsers` field to `Command`.

### How is this different from `Command#permissions`?

`allowedRoles` and `allowedUsers` are a discord specific endpoint that prevents users from even initiating commands in the first place. For example if you're not allowed to run the `tester` command you'll see this:
<img width="235" alt="Screen Shot 2021-07-18 at 4 29 03 PM" src="https://user-images.githubusercontent.com/77477100/126081281-acd27039-463e-4ffb-b6a2-ec84cb21ec75.png">

It's grayed out and un-selectable. 

### So is the role checking in our `permissions` field useless now?

No, the role checking we crafted is dynamic by nature, it can change based off of input given to a certain commands. The discord API is static, once the permissions are set they don't change, unless the command itself is overwritten.